### PR TITLE
Fix actions checkout error by updating it to the latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       run: yum install -y tar gzip
 
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Create the folder object type on S3
       run: aws s3api put-object --bucket s3-directory-listing --key folder-test-case/


### PR DESCRIPTION
According to https://github.com/actions/checkout/issues/1487 this error "/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)" is caused by a combination of the latest image and obsolete action version (using outdated node version).

Other sources worth considering:
* https://github.com/actions/checkout/issues/1474
* https://github.com/actions/checkout/issues/1590
* https://github.com/paragikjain/citus/commit/2874d7af4691377217e65e06694e85d0411db688